### PR TITLE
Add Italian program info in Italian

### DIFF
--- a/docs/README-fr.md
+++ b/docs/README-fr.md
@@ -1,5 +1,6 @@
 [:uk: EN](README.md "English")&nbsp;&nbsp;
 [:ru: RU](README-ru.md "Russian")
+[:it: IT](README-it.md "Italian")
 
 ---
 Auto Screenshot

--- a/docs/README-it.md
+++ b/docs/README-it.md
@@ -1,5 +1,5 @@
 [:uk: EN](README.md "English")&nbsp;&nbsp;
-[:fr: FR](README-fr.md "French")
+[:fr: FR](README-fr.md "French")&nbsp;&nbsp;
 [:ru: RU](README-ru.md "Russian")
 
 -------------------------  

--- a/docs/README-it.md
+++ b/docs/README-it.md
@@ -1,6 +1,6 @@
-[:fr: FR](README-fr.md "French")&nbsp;&nbsp;
+[:en: EN](README.md "English")&nbsp;&nbsp;
+[:fr: FR](README-fr.md "French")
 [:ru: RU](README-ru.md "Russian")
-[:it: IT](README-it.md "Italian")
 
 -------------------------  
 

--- a/docs/README-it.md
+++ b/docs/README-it.md
@@ -1,0 +1,112 @@
+[:fr: FR](README-fr.md "French")&nbsp;&nbsp;
+[:ru: RU](README-ru.md "Russian")
+[:it: IT](README-it.md "Italian")
+
+-------------------------  
+
+Auto Screenshot
+===============
+
+[![Release GitHub (versione più recente)](https://img.shields.io/github/v/release/artem78/AutoScreenshot?style=plastic)](https://github.com/artem78/AutoScreenshot/releases/latest)
+[![Licenza GitHub](https://img.shields.io/github/license/artem78/AutoScreenshot?style=plastic)](https://github.com/artem78/AutoScreenshot/blob/master/LICENSE.txt)
+![Tutte le release GitHub](https://img.shields.io/github/downloads/artem78/AutoScreenshot/total?style=plastic)
+![Ultimo commit GitHub](https://img.shields.io/github/last-commit/artem78/AutoScreenshot?style=plastic)
+[![Supporto Windows](https://img.shields.io/badge/support-Windows-blue?logo=Windows&style=plastic)](https://github.com/artem78/AutoScreenshot/releases/latest)
+[![Supporto Linux](https://img.shields.io/badge/support-Linux-white?logo=Linux&style=plastic)](https://github.com/artem78/AutoScreenshot/releases/latest)
+
+## Panoramica
+**Auto Screenshot** — applicazione per l'acquisizione automatica di schermate con intervallo di tempo specificato.
+
+## Funzionalità
+* Salvataggio automatico schermate a schermo intero con intervallo di tempo specificato (da 1 secondo a 24 ore)
+* Salvataggio immagini in formato PNG, JPEG, BMP, TIFF, WEBP o AVIF
+* Opzione pausa acquisizione quando l'utente non è attivo (a seconda dei movimenti del mouse e degli eventi della tastiera)
+* Nomi dei file output personalizzabili con variabili (data, ora, utente, nome computer, numero sequenziale) e possibilità di raggruppamento per cartelle (ad esempio: per giorno o mese)
+* L'acquisizione automatica può essere eseguita all'avvio del sistema
+* Supporto schermi multipli
+* Supporto DPI elevati
+* Può eseguire comandi personalizzati prima/dopo aver acquisito la schermata
+* Cancellazione vecchie schermate
+* Riproduce un suono quando viene catturata la schermata
+* Tasti rapidi
+* Funziona con Windows e Linux
+* Assolutamente gratuito e open source
+
+## Schermate
+<!--
+![Finestra principale programma in Windows 7](images/main_window.png "Main program window in Windows 7")
+
+![Icona barra di sistema](images/tray_icon_animation.gif "Tray icon")
+-->
+
+![Finestra principale app in Linux Mint](images/main_window_in_linux_mint.png "Main window in Linux Mint")
+
+![Modelli predefiniti nomi file](images/filename_template_samples.png "Predefined filename templates")
+
+![Descrizione variabili nomi file](images/filename_template_vars.png "Filename variables description")
+
+![Selezione formato immagine](images/image_format_selection.png "Image format selection")
+
+![Selezione monitor](images/monitors.png "Monitor selection")
+
+![Tasti rapidi](images/hotkeys.png "Hotkeys")
+
+## Lingue
+* Inglese
+* [Russo](README-ru.md)
+* Cinese
+* Ucraino
+* Poroghese
+* Spagnolo
+* Turco
+* Tedesco
+* [Francese](README-fr.md)
+* [Italiano](README-it.md)
+
+[(Aiutaci con la traduzione)](https://github.com/artem78/AutoScreenshot/issues/5)
+
+## Sistemi operativi supportati
+* Microsoft Windows XP o versione successiva (32/64-bit)
+* Linux
+
+## Download
+Download programma [qui](https://github.com/artem78/AutoScreenshot/releases/).
+
+### Windows
+Puoi scegliere tra file zip versione portatile o programma di installazione.
+
+### Linux
+Per Linux sono disponibili la versione portatile e il pacchetto deb. Testato con Linux Mint e Ubuntu.
+
+<!--
+**Nota:** per abilitare le funzionalità di rete, come il controllo degli aggiornamenti, assicurati di aver installato le librerie SSL (incluso il pacchetto di sviluppo).
+```
+sudo apt-get install openssl libssl-dev
+```
+-->
+
+## Compilazione dai sorgenti
+
+Descritto in [/docs/build.md](/docs/build.md)
+
+## Come posso aiutare?
+* [Segnalando i problemi riscontrati](https://github.com/artem78/AutoScreenshot/issues/new?assignees=&labels=bug&template=bug_report.md&title=)
+* [Suggerendo nuove idee o funzioni](https://github.com/artem78/AutoScreenshot/issues/new?assignees=&labels=enhancement&template=feature_request.md&title=)
+* [Creando una nuova traduzione](https://github.com/artem78/AutoScreenshot/issues/5)
+* [Facendo una donazione](#donate)
+
+## Licenza
+Sei libero di usare, modificare o distribuire questo software sotto licenza [GNU GPL v3.0](https://github.com/artem78/AutoScreenshot/blob/master/LICENSE.txt).
+
+## Author
+Artem78 (email: [megabyte1024@ya.ru](mailto:megabyte1024@ya.ru?subject=AutoScreenshot))
+
+## Dona
+- PayPal: megabyte1024@yandex.com
+- ETH Ethereum / Tether USDT: 0xB14C877b2eAF7E3b4b49df25039122C0545edA74
+- Webmoney WMZ: [Z598881055273](https://pay.web.money/d/kgfx)
+- Sberbank card: 5469 4009 8490 5476
+- ЮMoney (yoomoney): [4100 1195 0619 6001](https://yoomoney.ru/to/4100119506196001)
+
+## Collegamenti
+- [Sito web Auto Screenshot](https://artem78.github.io/AutoScreenshot/)

--- a/docs/README-it.md
+++ b/docs/README-it.md
@@ -1,4 +1,4 @@
-[:en: EN](README.md "English")&nbsp;&nbsp;
+[:uk: EN](README.md "English")&nbsp;&nbsp;
 [:fr: FR](README-fr.md "French")
 [:ru: RU](README-ru.md "Russian")
 

--- a/docs/README-it.md
+++ b/docs/README-it.md
@@ -52,7 +52,7 @@ Auto Screenshot
 ![Tasti rapidi](images/hotkeys.png "Hotkeys")
 
 ## Lingue
-* Inglese
+* [Inglese](README.md)
 * [Russo](README-ru.md)
 * Cinese
 * Ucraino
@@ -61,7 +61,7 @@ Auto Screenshot
 * Turco
 * Tedesco
 * [Francese](README-fr.md)
-* [Italiano](README-it.md)
+* Italiano
 
 [(Aiutaci con la traduzione)](https://github.com/artem78/AutoScreenshot/issues/5)
 

--- a/docs/README-ru.md
+++ b/docs/README-ru.md
@@ -1,6 +1,6 @@
 [:uk: EN](README.md "English")&nbsp;&nbsp;
 [:fr: FR](README-fr.md "French")
-[:it: FR](README-it.md "Italian")
+[:it: IT](README-it.md "Italian")
 
 ----------------
 

--- a/docs/README-ru.md
+++ b/docs/README-ru.md
@@ -1,5 +1,6 @@
 [:uk: EN](README.md "English")&nbsp;&nbsp;
 [:fr: FR](README-fr.md "French")
+[:it: FR](README-it.md "Italian")
 
 ----------------
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,6 @@
 [:fr: FR](README-fr.md "French")&nbsp;&nbsp;
 [:ru: RU](README-ru.md "Russian")
+[:ru: RU](README-it.md "Italian")
 
 -------------------------  
 
@@ -108,4 +109,4 @@ Artem78 (email: [megabyte1024@ya.ru](mailto:megabyte1024@ya.ru?subject=AutoScree
 - ЮMoney (yoomoney): [4100 1195 0619 6001](https://yoomoney.ru/to/4100119506196001)
 
 ## Links
-- [AutoScreenshot website](https://artem78.github.io/AutoScreenshot/)
+- [Auto Screenshot website](https://artem78.github.io/AutoScreenshot/)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 [:fr: FR](README-fr.md "French")&nbsp;&nbsp;
 [:ru: RU](README-ru.md "Russian")
-[:IT: IT](README-it.md "Italian")
+[:it: IT](README-it.md "Italian")
 
 -------------------------  
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -61,7 +61,7 @@ Auto Screenshot
 * Turkish
 * German
 * [French](README-fr.md)
-* Italian
+* [Italian](README-it.md)
 
 [(Help with new translations)](https://github.com/artem78/AutoScreenshot/issues/5)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 [:fr: FR](README-fr.md "French")&nbsp;&nbsp;
 [:ru: RU](README-ru.md "Russian")
-[:ru: IT](README-it.md "Italian")
+[:IT: IT](README-it.md "Italian")
 
 -------------------------  
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 [:fr: FR](README-fr.md "French")&nbsp;&nbsp;
 [:ru: RU](README-ru.md "Russian")
-[:ru: RU](README-it.md "Italian")
+[:ru: IT](README-it.md "Italian")
 
 -------------------------  
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 [:fr: FR](README-fr.md "French")&nbsp;&nbsp;
-[:ru: RU](README-ru.md "Russian")
+[:ru: RU](README-ru.md "Russian")&nbsp;&nbsp;
 [:it: IT](README-it.md "Italian")
 
 -------------------------  

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,7 +25,7 @@ Auto Screenshot
 * Automatic capture can be started on system startup
 * Multiple screens support
 * High DPI support
-* Can execute custom command after screenshot was taken
+* Can execute custom command before and after screenshot was taken
 * Clearing old screenshots
 * Play sound when screenshot taken
 * Hotkeys

--- a/lang/it.ini
+++ b/lang/it.ini
@@ -2,7 +2,7 @@
 LangCode=it
 LangName=Italiano
 LangNativeName=Italian
-\Author=RB (traduzione v. 10.04.2026)
+Author=RB (traduzione v. 07.05.2026)
 
 [translation]
 ; === Main window ===
@@ -26,8 +26,8 @@ StopCapture=Stop
 TakeScreenshot=Cattura schermata
 About=Info programma
 StartCaptureOnStartUp=Avvia acquisizione automatica all'avvio del programma
-StartMinimized=Esegui il programma minimizzato nella barra di sistema
-AutoRun=Esegui il programma all'avvio del sistema
+StartMinimized=Esegui programma minimizzato nella barra di sistema
+AutoRun=Esegui programma all'avvio del sistema
 FileNameTemplate=Modello nome file
 FileNameTemplateHelpText=Variabili disponibili:\r\n%D\t- giorno (2 cifre)\r\n%M\t- mese (2 cifre)\r\n%Y\t- anno (4 cifre)\r\n%H\t- ore (2 cifre)\r\n%N\t- minuti (2 cifre)\r\n%S\t- secondi (2 cifre)\r\n%COMP\t- nome computer\r\n%USER\t- nome utente\r\n%NUM\t- numero incrementale schermata\r\n\r\nPuoi usare le cartelle per raggruppare le schermate (ad esempio: per giorno o mese).\r\nNon è necessario specificare l'estensione del file.\r\n\r\nEsempio 1:\r\nQuando usi  il modello "%Y-%M-%D\\schermata_%H-%N-%S", verrà creato il file con nome "schermata_12-34-56.png" nella cartella "2026-04-19".\r\n\r\nEsempio 2:\r\nQuando usi il modello  "schermata_%NUM" con il numero incrementale con 6 cifre6, il file della 123sima schermata si chiamerà "schermata_000123.png".
 UsedMonitor=Monitor usato
@@ -36,7 +36,7 @@ MonitorInfo=Monitor #%d (%d x %d)
 Primary=primario
 SequentialNumber=Numero incrementale (variabile %NUM)
 NextValue=Valore successivo
-Digits=N cifre
+Digits=N. cifre
 RunCommand=Esegui comando (dopo)
 RunCommandHelpText=Variabili disponibili: %FILENAME%\r\nEsempio: %s
 MonitorWithCursor=Segui cursore
@@ -57,11 +57,19 @@ Months=mesi
 PlaySounds=Riproduci suono
 MinimizeInSteadOfClose=Quando chiudi la finestra minimizza nella barra di sistema
 File=File
-TryPro=Prova PRO
-ProBannerText1=Prova la versione
-ProBannerText2=con funzioni avanzate!
-ProBannerText3=Maggiori info...
 VisitHomepage=Visita sito web
+RunCommandBefore=Esegui comando (prima)
+RunCommandBeforeHelpText=Esempio: %s
+SkipSimilar=Salta schermate simili
+SkipSimilarHint=Non salvare schermata se differisce poco dalla precedente
+Match=Corrispodenza
+AutoCapturePaused=Cattura automatica in pausa per inattività utente...
+TimeToNextShot=Tempo per la prossima cattura: %s
+ScreenshotSkipped=Schermata simile ignorata
+ScreenshotSaved=Schermata salvata nel file '%s'
+AutoCaptureDisabled=Cattura automatica disabilitata
+HelpWithTranslation=Aiutaci con la traduzione
+ReportIssue=Segnala problema
 
 ; === Tray icon menu ===
 Restore=Visualizza finestra AutoScreenshot
@@ -82,11 +90,13 @@ ExitConfirmation=Vuoi uscire dal programma?
 
 ; === Update window ===
 NoUpdatesFound=Questa versione è aggiornata.\r\nNessuna nuova versione disponibile.
-UpdateFound=È disponibile la nuova versione '%s'!\r\nVersione attuale: '%s'.
+UpdateFound=È disponibile una nuova versione!\r\nVersione disponibile: '%s'\r\nVersione installata:%s \r\n.
 AskDownloadUpdate=Vuoi aprire la pagina web per il download della nuova versione?
 UpdateCheckFailed=Controllo aggiornamenti non riuscito
-CheckingForUpdates=Controlla aggiornamenti...
+CheckingForUpdates=Controllo aggiornamenti...
 CheckForUpdatesWindowCaption=Controllo aggiornamenti
+NoData=(empty)
+Changelog=Changelog
 
 ; === Hotkeys window ===
 HotKeys=Tasti rapidi
@@ -98,6 +108,8 @@ HotKeyOccupied=Tasto rapido già in uso!
 
 ; === Donate window ===
 Copy=Copia
+DonateInfo=Auto Screenshot può essere usato gratuitamente da tutti. Tuttavia, puoi aiutare questo progetto a migliorare con una donazionei. In questo modo ringrazierai l'autore per il tempo e le risorse spese nel corso degli anni per lo sviluppo e la risoluzione dei problemi. Nessun limite minimo di donazione. Accettati diversi metodi di pagamento.
+OpenPayLinkInBrowser=Apri collegamento pagina web pagamento nel browser
 
 ; === General ====
 Yes=Sì


### PR DESCRIPTION
@artem78 

Please merge. Thanks.

Note: in RU/FR README there some function missing compared with English readme
- Missing info about Italian language
- Misisng info about Auto Screenshot web site
- The ballon help about screenshots regarding the program are in English and not in local languages (RU o FR).
 
In English README change "AutoScreenshot website" in "Auto Screenshot website"

About program features is report that program can run command after capture.
Is it right that the program can also run command before capture?

Thanks.